### PR TITLE
Adjust the default minimum version in the PDF template

### DIFF
--- a/src/Cli/Commands/CreateTemplate.php
+++ b/src/Cli/Commands/CreateTemplate.php
@@ -225,7 +225,7 @@ class CreateTemplate {
 			'author_uri'       => '',
 			'group'            => 'Custom',
 			'license'          => '',
-			'required_version' => '4.0.0',
+			'required_version' => '4.4.0',
 			'tags'             => '',
 		];
 
@@ -238,7 +238,7 @@ class CreateTemplate {
 				'author_uri'       => 'Author website: ',
 				'group'            => 'Group name: ',
 				'license'          => 'License (if any): ',
-				'required_version' => 'Minimum Gravity PDF version (defaults to 4.0): ',
+				'required_version' => 'Minimum Gravity PDF version (defaults to 4.4.0): ',
 				'tags'             => 'Tags (separate by comma): ',
 			];
 

--- a/tests/phpunit/unit-tests/Commands/TestCreateTemplate.php
+++ b/tests/phpunit/unit-tests/Commands/TestCreateTemplate.php
@@ -194,7 +194,7 @@ namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands {
 			$this->assertRegExp( '/\* Author: /', $fileContents );
 			$this->assertRegExp( '/\* Author URI: /', $fileContents );
 			$this->assertRegExp( '/\* Group: /', $fileContents );
-			$this->assertRegExp( '/\* Required PDF Version: 4.0.0/', $fileContents );
+			$this->assertRegExp( '/\* Required PDF Version: 4.4.0/', $fileContents );
 		}
 
 		/**
@@ -218,7 +218,7 @@ namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands {
 			$this->assertRegExp( '/\* Author: /', $fileContents );
 			$this->assertRegExp( '/\* Author URI: /', $fileContents );
 			$this->assertRegExp( '/\* Group: /', $fileContents );
-			$this->assertRegExp( '/\* Required PDF Version: 4.0.0/', $fileContents );
+			$this->assertRegExp( '/\* Required PDF Version: 4.4.0/', $fileContents );
 			$this->assertRegExp( '/\* Toolkit: true/', $fileContents );
 		}
 


### PR DESCRIPTION
Change from 4.0 to 4.4.0 as the default minimum Gravity PDF version in PDF templates. This will accommodate Toolkit templates that require Gravity PDF 4.4 and the Dev Toolkit to function.

Resolves #5