### PR TITLE
Inject the WP_CLI class into our CreateTemplate class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "autoloader-suffix": "GravityPDFDeveloperToolkitAddon"
   },
   "require-dev": {
-    "phpunit/phpunit": ">4.0 <7"
+    "phpunit/phpunit": ">4.0 <7",
+    "wp-cli/wp-cli": "^1.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Cli/Commands/Cli.php
+++ b/src/Cli/Commands/Cli.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace GFPDF\Plugins\DeveloperToolkit\Cli;
+namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands;
 
-use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\Cli;
-use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\CreateTemplate;
 use WP_CLI;
 
 /**
@@ -39,22 +37,71 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 
 /**
- * Registers our WP CLI Commands
+ * Class Cli
  *
- * @package GFPDF\Plugins\DeveloperToolkit\Cli
+ * @package GFPDF\Plugins\DeveloperToolkit\Cli\Commands
+ *
+ * @since   1.0
  */
-class Register {
+class Cli implements InterfaceCli {
 
 	/**
-	 * Register our WP CLI Commands
+	 * Logs a message
+	 *
+	 * @param string $text
 	 *
 	 * @since 1.0
 	 */
-	public function init() {
-		global $gfpdf;
+	public function log( $text ) {
+		WP_CLI::log( $text );
+	}
 
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'gpdf create-template', new CreateTemplate( $gfpdf->data->template_location, new Cli() ) );
-		}
+	/**
+	 * Logs a warning message
+	 *
+	 * @param string $text
+	 *
+	 * @since 1.0
+	 */
+	public function warning( $text ) {
+		WP_CLI::warning( $text );
+	}
+
+	/**
+	 * Logs a success message
+	 *
+	 * @param string $text
+	 *
+	 * @since 1.0
+	 */
+	public function success( $text ) {
+		WP_CLI::success( $text );
+	}
+
+	/**
+	 * Logs an error
+	 *
+	 * @param string $text
+	 * @param bool   $exit
+	 *
+	 * @since 1.0
+	 * @throws WP_CLI\ExitException
+	 */
+	public function error( $text, $exit = true ) {
+		WP_CLI::error( $text, $exit );
+	}
+
+	/**
+	 * Ask the CLI user a question and return their response
+	 *
+	 * @param string $question
+	 *
+	 * @return string
+	 *
+	 * @since 1.0
+	 */
+	public function getResponse( $question ) {
+		fwrite( STDOUT, $question );
+		return trim( fgets( STDIN ) );
 	}
 }

--- a/src/Cli/Commands/InterfaceCli.php
+++ b/src/Cli/Commands/InterfaceCli.php
@@ -1,10 +1,6 @@
 <?php
 
-namespace GFPDF\Plugins\DeveloperToolkit\Cli;
-
-use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\Cli;
-use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\CreateTemplate;
-use WP_CLI;
+namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands;
 
 /**
  * @package     Gravity PDF Developer Toolkit
@@ -39,22 +35,59 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 
 /**
- * Registers our WP CLI Commands
+ * Interface InterfaceWriter
  *
- * @package GFPDF\Plugins\DeveloperToolkit\Cli
+ * For use as our WP_CLI Interface
+ *
+ * @package GFPDF\Plugins\DeveloperToolkit\Cli\Commands
+ *
+ * @since   1.0
  */
-class Register {
+interface InterfaceCli {
 
 	/**
-	 * Register our WP CLI Commands
+	 * Logs a message
+	 *
+	 * @param string $text
 	 *
 	 * @since 1.0
 	 */
-	public function init() {
-		global $gfpdf;
+	public function log( $text );
 
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'gpdf create-template', new CreateTemplate( $gfpdf->data->template_location, new Cli() ) );
-		}
-	}
+	/**
+	 * Logs a warning message
+	 *
+	 * @param string $text
+	 *
+	 * @since 1.0
+	 */
+	public function warning( $text );
+
+	/**
+	 * Logs a success message
+	 *
+	 * @param string $text
+	 *
+	 * @since 1.0
+	 */
+	public function success( $text );
+
+	/**
+	 * Logs an error
+	 *
+	 * @param string $text
+	 * @param bool   $exit
+	 *
+	 * @since 1.0
+	 */
+	public function error( $text, $exit = true );
+
+	/**
+	 * Get a user response
+	 *
+	 * @return string
+	 *
+	 * @since 1.0
+	 */
+	public function getResponse( $text );
 }


### PR DESCRIPTION
This allows us to easily override the WP_CLI's behaviour, even though the methods being called are static, and keep the wp-cli dev dependancy.