### PR TITLE
Create two CLI commands to get Gravity PDF Status

### DIFF
--- a/src/Cli/Commands/Cli.php
+++ b/src/Cli/Commands/Cli.php
@@ -104,4 +104,17 @@ class Cli implements InterfaceCli {
 		fwrite( STDOUT, $question );
 		return trim( fgets( STDIN ) );
 	}
+
+	/**
+	 * Output the data in a specific format
+	 *
+	 * @param string $format Either 'table', 'json', 'csv' or 'yaml'
+	 * @param array  $data   In the format [ [ 'Key' => 'Value' ], [ 'Key' => 'Value' ] ]
+	 * @param array  $keys   The Keys used in $data
+	 *
+	 * @since 1.0
+	 */
+	public function outputInFormat( $format, $data, $keys ) {
+		\WP_CLI\Utils\format_items( $format, $data, $keys );
+	}
 }

--- a/src/Cli/Commands/GetPdfStatus.php
+++ b/src/Cli/Commands/GetPdfStatus.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands;
+
+use GFPDF\Helper\Helper_Abstract_Options;
+use GFPDF\Helper\Helper_Data;
+
+/**
+ * @package     Gravity PDF Developer Toolkit
+ * @copyright   Copyright (c) 2018, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       1.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF Developer Toolkit.
+
+    Copyright (c) 2018, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * The Gravity PDF CLI Commands
+ *
+ * @package GFPDF\Plugins\DeveloperToolkit\Cli\Commands
+ */
+class GetPdfStatus {
+
+	/**
+	 * @var Helper_Data
+	 */
+	protected $data;
+
+	/**
+	 * @var Helper_Abstract_Options
+	 */
+	protected $options;
+
+	/**
+	 * @var \WP_CLI
+	 */
+	protected $cli;
+
+	/**
+	 * @param Helper_Data  $data The Gravity PDF data object
+	 * @param InterfaceCli $cli  The WP_CLI class, or a suitable drop-in replacement (for testing)
+	 *
+	 * @since 1.0
+	 */
+	public function __construct( Helper_Data $data, Helper_Abstract_Options $options, InterfaceCli $cli ) {
+		$this->data    = $data;
+		$this->options = $options;
+		$this->cli     = $cli;
+	}
+
+	/**
+	 * Get the current Gravity PDF Version
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get current Gravity PDF version
+	 *     $ wp gpdf version
+	 *
+	 * @since 1.0
+	 */
+	public function version() {
+		$this->cli->log( PDF_EXTENDED_VERSION );
+	}
+
+	/**
+	 * Get the Gravity PDF System Status
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv, yaml. Defaults to table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get current Gravity PDF Status in Tabular Format
+	 *     $ wp gpdf status
+	 *
+	 *     # Get current Gravity PDF Status in JSON format
+	 *     $ wp gpdf status --format=json
+	 *
+	 *     # Get current Gravity PDF Status in YAML format
+	 *     $ wp gpdf status --format=yaml
+	 *
+	 *     # Get current Gravity PDF Status in CSV format
+	 *     $ wp gpdf status --format=csv
+	 *
+	 * @param array $args      No standard arguments used
+	 * @param array $assocArgs The additional arguments passed to the cli. May include `format`
+	 *
+	 * @since 1.0
+	 */
+	public function status( $args, $assocArgs ) {
+		/* Get the desired format */
+		$format = 'table';
+		if ( isset( $assocArgs['format'] ) && in_array( $assocArgs['format'], [ 'csv', 'json', 'yaml' ] ) ) {
+			$format = $assocArgs['format'];
+		}
+
+		$this->cli->outputInFormat( $format, $this->getStatusData(), [
+			__( 'Setting', 'gravity-pdf-developer-toolkit' ),
+			__( 'Value', 'gravity-pdf-developer-toolkit' ),
+		] );
+	}
+
+	/**
+	 * Get the PDF Status data
+	 *
+	 * @return array
+	 *
+	 * @since 1.0
+	 */
+	protected function getStatusData() {
+		$settings = $this->options->get_settings();
+
+		$settingKey = __( 'Setting', 'gravity-pdf-developer-toolkit' );
+		$valueKey   = __( 'Value', 'gravity-pdf-developer-toolkit' );
+
+		/* Prepare the data for display */
+		$data = [];
+
+		$data[] = [
+			$settingKey => __( 'Version', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => PDF_EXTENDED_VERSION,
+		];
+
+		$data[] = [
+			$settingKey => __( 'Working Directory Folder', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->working_folder,
+		];
+
+		$data[] = [
+			$settingKey => __( 'Working Directory Path', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->template_location,
+		];
+
+		if ( is_multisite() ) {
+			$data[] = [
+				$settingKey => __( 'Subsite Working Directory', 'gravity-pdf-developer-toolkit' ),
+				$valueKey   => $this->data->multisite_template_location,
+			];
+		}
+
+		$data[] = [
+			$settingKey => __( 'Font Directory Path', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->template_font_location,
+		];
+
+		$data[] = [
+			$settingKey => __( 'Font Data Directory Path', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->template_fontdata_location,
+		];
+
+		$data[] = [
+			$settingKey => __( 'Temporary Directory Path', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->template_tmp_location,
+		];
+
+		$data[] = [
+			$settingKey => __( 'Memory Limit', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $this->data->memory_limit,
+		];
+
+		if ( count( $this->data->addon ) > 0 ) {
+			$addons = [];
+			foreach ( $this->data->addon as $addon ) {
+				$addons[] = $addon->get_name();
+			}
+
+			$data[] = [
+				$settingKey => __( 'Installed Extensions', 'gravity-pdf-developer-toolkit' ),
+				$valueKey   => implode( ', ', $addons ),
+			];
+		}
+
+		$data[] = [
+			$settingKey => __( 'Default Template', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_template'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Default Font', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_font'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Default Font Size', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_font_size'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Default RTL', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_rtl'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Default PDF Action', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_action'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Shortcode Debugging', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => ( $settings['shortcode_debug_messages'] === 'Yes' ) ? 'Enabled' : 'Disabled',
+		];
+
+		$data[] = [
+			$settingKey => __( 'PDF Admin Capabilities', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => implode( ', ', $settings['admin_capabilities'] ),
+		];
+
+		$data[] = [
+			$settingKey => __( 'Default Restrict Current Owner', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['default_restrict_owner'],
+		];
+
+		$data[] = [
+			$settingKey => __( 'Logged Out Timeout', 'gravity-pdf-developer-toolkit' ),
+			$valueKey   => $settings['logged_out_timeout'],
+		];
+
+		if ( is_array( $settings['custom_fonts'] ) && count( $settings['custom_fonts'] ) > 0 ) {
+			$fonts = [];
+			foreach ( $settings['custom_fonts'] as $font ) {
+				$fonts[] = $font['font_name'];
+			}
+
+			$data[] = [
+				$settingKey => __( 'Installed Fonts', 'gravity-pdf-developer-toolkit' ),
+				$valueKey   => implode( ", ", $fonts ),
+			];
+		}
+
+		return $data;
+	}
+}

--- a/src/Cli/Commands/InterfaceCli.php
+++ b/src/Cli/Commands/InterfaceCli.php
@@ -85,9 +85,22 @@ interface InterfaceCli {
 	/**
 	 * Get a user response
 	 *
+	 * @value string $text
+	 *
 	 * @return string
 	 *
 	 * @since 1.0
 	 */
 	public function getResponse( $text );
+
+	/**
+	 * Output the data in a specific format
+	 *
+	 * @param string $format Either 'table', 'json', 'csv' or 'yaml'
+	 * @param array  $data   In the format [ [ 'Key' => 'Value' ], [ 'Key' => 'Value' ] ]
+	 * @param array  $keys   The Keys used in $data
+	 *
+	 * @since 1.0
+	 */
+	public function outputInFormat( $format, $data, $keys );
 }

--- a/src/Cli/Register.php
+++ b/src/Cli/Register.php
@@ -4,6 +4,7 @@ namespace GFPDF\Plugins\DeveloperToolkit\Cli;
 
 use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\Cli;
 use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\CreateTemplate;
+use GFPDF\Plugins\DeveloperToolkit\Cli\Commands\GetPdfStatus;
 use WP_CLI;
 
 /**
@@ -54,6 +55,7 @@ class Register {
 		global $gfpdf;
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'gpdf', new GetPdfStatus( $gfpdf->data, $gfpdf->options, new Cli() ) );
 			WP_CLI::add_command( 'gpdf create-template', new CreateTemplate( $gfpdf->data->template_location, new Cli() ) );
 		}
 	}

--- a/tests/phpunit/unit-tests/Commands/TestCreateTemplate.php
+++ b/tests/phpunit/unit-tests/Commands/TestCreateTemplate.php
@@ -64,7 +64,7 @@ class TestCreateTemplate extends WP_UnitTestCase {
 	public function setUp() {
 		$this->path = __DIR__ . '/../../../../tmp/';
 
-		$cli = $this->getMockBuilder( Cli::class )
+		$cli = $this->getMockBuilder( CreateTemplateCli::class )
 		            ->setMethods( [ 'getResponse' ] )
 		            ->getMock();
 
@@ -266,7 +266,7 @@ class TestCreateTemplate extends WP_UnitTestCase {
 	}
 }
 
-class Cli implements InterfaceCli {
+class CreateTemplateCli implements InterfaceCli {
 	public function log( $text ) {
 		echo $text;
 	}
@@ -285,6 +285,10 @@ class Cli implements InterfaceCli {
 	}
 
 	public function getResponse( $text ) {
+
+	}
+
+	public function outputInFormat( $format, $data, $keys ) {
 
 	}
 }

--- a/tests/phpunit/unit-tests/Commands/TestGetPdfStatus.php
+++ b/tests/phpunit/unit-tests/Commands/TestGetPdfStatus.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace GFPDF\Plugins\DeveloperToolkit\Cli\Commands;
+
+use WP_UnitTestCase;
+use Exception;
+
+/**
+ * @package     Gravity PDF Developer Toolkit
+ * @copyright   Copyright (c) 2018, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       1.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF Developer Toolkit.
+
+	Copyright (C) 2018, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class TestGetPdfStatus
+ *
+ * @package GFPDF\Plugins\DeveloperToolkit\Cli\Commands
+ *
+ * @group   commands
+ */
+class TestGetPdfStatus extends WP_UnitTestCase {
+
+	/**
+	 * @var GetPdfStatus
+	 * @since 1.0
+	 */
+	private $class;
+
+	/**
+	 * @var string
+	 * @since 1.0
+	 */
+	private $path;
+
+	/**
+	 * @since 1.0
+	 */
+	public function setUp() {
+		$this->path = __DIR__ . '/../../../../tmp/';
+
+		$cli = $this->getMockBuilder( GetPdfStatusCli::class )
+		            ->setMethods( [ 'getResponse' ] )
+		            ->getMock();
+
+		$this->class = new GetPdfStatus( \GPDFAPI::get_data_class(), \GPDFAPI::get_options_class(), $cli );
+
+		parent::setUp();
+	}
+
+	/**
+	 * @since 1.0
+	 */
+	public function testVersion() {
+		ob_start();
+		$this->class->version();
+		$content = ob_get_clean();
+
+		$this->assertEquals( PDF_EXTENDED_VERSION, $content );
+	}
+
+	/**
+	 * @since 1.0
+	 */
+	public function testStatus() {
+		ob_start();
+		$this->class->status( [], [] );
+		$results = json_decode( ob_get_clean(), true );
+
+		$this->assertEquals( 'table', $results[0] );
+		$this->assertCount( ( ! is_multisite() ) ? 17 : 18, $results[1] );
+		$this->assertCount( 2, $results[2] );
+
+		ob_start();
+		$this->class->status( [], [ 'format' => 'json' ] );
+		$results = json_decode( ob_get_clean(), true );
+
+		$this->assertEquals( 'json', $results[0] );
+	}
+}
+
+class GetPdfStatusCli implements InterfaceCli {
+	public function log( $text ) {
+		echo $text;
+	}
+
+	public function warning( $text ) {
+		echo $text;
+	}
+
+	public function success( $text ) {
+		echo $text;
+	}
+
+	public function error( $text, $exit = true ) {
+		echo $text;
+		throw new Exception();
+	}
+
+	public function getResponse( $text ) {
+
+	}
+
+	public function outputInFormat( $format, $data, $keys ) {
+		echo json_encode( [ $format, $data, $keys ] );
+	}
+}


### PR DESCRIPTION
Add `wp gpdf version` and `wp gpdf status` commands.

We've not used __invoke to allow the description to populate the `wp gpdf`command when typing `wp`. This is a one-time occurrence. 