### PR TITLE
Add support for center and right alignment fixed-pos methods

### DIFF
--- a/src/Writer/Processes/Multi.php
+++ b/src/Writer/Processes/Multi.php
@@ -46,14 +46,14 @@ class Multi extends AbstractWriter {
 
 	/**
 	 * @var int The default font size in points. This is overridden by the UI Font Size.
-	 * @see \GFPDF\Plugins\DeveloperToolkit\Loader\Loader::setDefaultStyles()
+	 * @see   \GFPDF\Plugins\DeveloperToolkit\Loader\Loader::setDefaultStyles()
 	 * @since 1.0
 	 */
 	protected $fontSize = 10;
 
 	/**
 	 * @var int The default line height in points. This is overridden by the (UI Font Size * 1.4).
-	 * @see \GFPDF\Plugins\DeveloperToolkit\Loader\Loader::setDefaultStyles()
+	 * @see   \GFPDF\Plugins\DeveloperToolkit\Loader\Loader::setDefaultStyles()
 	 * @since 1.0
 	 */
 	protected $lineHeight = 14;
@@ -98,7 +98,7 @@ class Multi extends AbstractWriter {
 	 *
 	 * @param string $html     The content to add to the PDF being rendered
 	 * @param array  $position The X, Y, Width and Height of the element
-	 * @param string $overflow Whether to show, hide or resize the $html if the content doesn't fit inside the width/height. Accepted arguments include "auto" or "visible"
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted arguments include "auto" or "visible"
 	 * @param array  $config   Override the default configuration on a per-element basis. Accepted array keys include 'font-size', 'line-height', 'strip-br'
 	 *
 	 * @throws BadMethodCallException Will be thrown if `$position` doesn't include four array items (x, y, width, height), if `$overflow` doesn't include an accepted argument, or $html is not a string
@@ -143,6 +143,50 @@ class Multi extends AbstractWriter {
 		);
 
 		$this->mpdf->WriteFixedPosHTML( $output, $position[0], $position[1], $position[2], $position[3], $overflow );
+	}
+
+	/**
+	 * Add Multi-line content to the PDF
+	 *
+	 * @see   Multi::addMulti() for full documentation
+	 *
+	 * ## Example
+	 *
+	 *      // Add multi-line content to the current page positioned 20mm from the left, 50mm from the top, with a width of 30mm, a height of 5mm and aligned right
+	 *      $w->addMultiCenter( 'Line 1<br>Line2<br>Line3', [ 20, 50, 30, 5 ] );
+	 *
+	 * @param string $html     The content to add to the PDF being rendered
+	 * @param array  $position The X, Y, Width and Height of the element
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted arguments include "auto" or "visible"
+	 * @param array  $config   Override the default configuration on a per-element basis. Accepted array keys include 'font-size', 'line-height', 'strip-br'
+	 *
+	 * @since 1.0.0-beta2
+	 */
+	public function addMultiCenter( $html, $position = [], $overflow = 'auto', $config = [] ) {
+		$html = '<div style="text-align: center">' . $html . '</div>';
+		$this->addMulti( $html, $position, $overflow, $config );
+	}
+
+	/**
+	 * Add Multi-line content to the PDF
+	 *
+	 * @see   Multi::addMulti() for full documentation
+	 *
+	 * ## Example
+	 *
+	 *      // Add content to the current page positioned 20mm from the left, 50mm from the top, with a width of 30mm, a height of 5mm and aligned right
+	 *      $w->addMultiRight( 'Line 1<br>Line2<br>Line3', [ 20, 50, 30, 5 ] );
+	 *
+	 * @param string $html     The content to add to the PDF being rendered
+	 * @param array  $position The X, Y, Width and Height of the element
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted arguments include "auto" or "visible"
+	 * @param array  $config   Override the default configuration on a per-element basis. Accepted array keys include 'font-size', 'line-height', 'strip-br'
+	 *
+	 * @since 1.0.0-beta2
+	 */
+	public function addMultiRight( $html, $position = [], $overflow = 'auto', $config = [] ) {
+		$html = '<div style="text-align: right">' . $html . '</div>';
+		$this->addMulti( $html, $position, $overflow, $config );
 	}
 
 	/**

--- a/src/Writer/Processes/Single.php
+++ b/src/Writer/Processes/Single.php
@@ -66,7 +66,7 @@ class Single extends AbstractWriter {
 	 *
 	 * @param string $html     The content to add to the PDF being rendered
 	 * @param array  $position The X, Y, Width and Height of the element
-	 * @param string $overflow Whether to show, hide or resize the $html if the content doesn't fit inside the width/height. Accepted parameters include "auto" or "visible"
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted parameters include "auto" or "visible"
 	 *
 	 * @throws BadMethodCallException Will be thrown if `$position` doesn't include four array items (x, y, width, height), if `$overflow` doesn't include an accepted argument, or $html is not a string
 	 *
@@ -92,5 +92,47 @@ class Single extends AbstractWriter {
 		);
 
 		$this->mpdf->WriteFixedPosHTML( $output, $position[0], $position[1], $position[2], $position[3], $overflow );
+	}
+
+	/**
+	 * Add Single Line content to PDF with center alignment
+	 *
+	 * @see   Single::add() for full documentation
+	 *
+	 * ## Example
+	 *
+	 *      // Add content to the current page positioned 20mm from the left, 50mm from the top, with a width of 30mm, a height of 5mm and aligned right
+	 *      $w->addCenter( 'My content', [ 20, 50, 30, 5 ] );
+	 *
+	 * @param string $html     The content to add to the PDF being rendered
+	 * @param array  $position The X, Y, Width and Height of the element
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted parameters include "auto" or "visible"
+	 *
+	 * @since 1.0.0-beta2
+	 */
+	public function addCenter( $html, $position = [], $overflow = 'auto' ) {
+		$html = '<div style="text-align: center">' . $html . '</div>';
+		$this->add( $html, $position, $overflow );
+	}
+
+	/**
+	 * Add Single Line content to PDF with right alignment
+	 *
+	 * @see   Single::add() for full documentation
+	 *
+	 * ## Example
+	 *
+	 *      // Add content to the current page positioned 20mm from the left, 50mm from the top, with a width of 30mm, a height of 5mm and aligned right
+	 *      $w->addRight( 'My content', [ 20, 50, 30, 5 ] );
+	 *
+	 * @param string $html     The content to add to the PDF being rendered
+	 * @param array  $position The X, Y, Width and Height of the element
+	 * @param string $overflow Whether to show or resize the $html if the content doesn't fit inside the width/height. Accepted parameters include "auto" or "visible"
+	 *
+	 * @since 1.0.0-beta2
+	 */
+	public function addRight( $html, $position = [], $overflow = 'auto' ) {
+		$html = '<div style="text-align: right">' . $html . '</div>';
+		$this->add( $html, $position, $overflow );
 	}
 }

--- a/tests/phpunit/unit-tests/Writer/Processes/TestMulti.php
+++ b/tests/phpunit/unit-tests/Writer/Processes/TestMulti.php
@@ -110,7 +110,7 @@ class TestMulti extends WP_UnitTestCase {
 
 		}
 
-		$this->assertEquals( '$overflow can only be "auto", "visible" or "hidden".', $e->getMessage() );
+		$this->assertEquals( '$overflow can only be "auto" or "visible".', $e->getMessage() );
 	}
 
 	/**
@@ -126,5 +126,35 @@ class TestMulti extends WP_UnitTestCase {
 		$this->class->addMulti( '', [ 10, 10, 10, 10 ] );
 		$this->class->addMulti( '', [ 10, 10, 10, 10 ] );
 		$this->class->addMulti( '', [ 10, 10, 10, 10 ] );
+	}
+
+	/**
+	 * @since 1.0
+	 */
+	public function testAddMultiCenter() {
+		$mpdf = $this->getMockBuilder( mPDF::class )->getMock();
+		$mpdf->expects( $this->exactly( 3 ) )
+		     ->method( 'WriteFixedPosHTML' );
+
+		$this->class->setMpdf( $mpdf );
+
+		$this->class->addMultiCenter( '', [ 10, 10, 10, 10 ] );
+		$this->class->addMultiCenter( '', [ 10, 10, 10, 10 ] );
+		$this->class->addMultiCenter( '', [ 10, 10, 10, 10 ] );
+	}
+
+	/**
+	 * @since 1.0
+	 */
+	public function testAddMultiRight() {
+		$mpdf = $this->getMockBuilder( mPDF::class )->getMock();
+		$mpdf->expects( $this->exactly( 3 ) )
+		     ->method( 'WriteFixedPosHTML' );
+
+		$this->class->setMpdf( $mpdf );
+
+		$this->class->addMultiRight( '', [ 10, 10, 10, 10 ] );
+		$this->class->addMultiRight( '', [ 10, 10, 10, 10 ] );
+		$this->class->addMultiRight( '', [ 10, 10, 10, 10 ] );
 	}
 }

--- a/tests/phpunit/unit-tests/Writer/Processes/TestSingle.php
+++ b/tests/phpunit/unit-tests/Writer/Processes/TestSingle.php
@@ -91,7 +91,7 @@ class TestSingle extends WP_UnitTestCase {
 
 		}
 
-		$this->assertEquals( '$overflow can only be "auto", "visible" or "hidden".', $e->getMessage() );
+		$this->assertEquals( '$overflow can only be "auto" or "visible".', $e->getMessage() );
 	}
 
 	/**
@@ -107,5 +107,35 @@ class TestSingle extends WP_UnitTestCase {
 		$this->class->add( '', [ 10, 10, 10, 10 ] );
 		$this->class->add( '', [ 10, 10, 10, 10 ] );
 		$this->class->add( '', [ 10, 10, 10, 10 ] );
+	}
+
+	/**
+	 * @since 1.0.0-beta2
+	 */
+	public function testaddCenter() {
+		$mpdf = $this->getMockBuilder( mPDF::class )->getMock();
+		$mpdf->expects( $this->exactly( 3 ) )
+		     ->method( 'WriteFixedPosHTML' );
+
+		$this->class->setMpdf( $mpdf );
+
+		$this->class->addCenter( '', [ 10, 10, 10, 10 ] );
+		$this->class->addCenter( '', [ 10, 10, 10, 10 ] );
+		$this->class->addCenter( '', [ 10, 10, 10, 10 ] );
+	}
+
+	/**
+	 * @since 1.0.0-beta2
+	 */
+	public function testaddRight() {
+		$mpdf = $this->getMockBuilder( mPDF::class )->getMock();
+		$mpdf->expects( $this->exactly( 3 ) )
+		     ->method( 'WriteFixedPosHTML' );
+
+		$this->class->setMpdf( $mpdf );
+
+		$this->class->addRight( '', [ 10, 10, 10, 10 ] );
+		$this->class->addRight( '', [ 10, 10, 10, 10 ] );
+		$this->class->addRight( '', [ 10, 10, 10, 10 ] );
 	}
 }


### PR DESCRIPTION
This allows `$w->addCenter`, `$w->addRight`, `$w->addMultiCenter` and `$w->addMultiRight` for quicker alignments in the PDF templates.

Resolves #26